### PR TITLE
update instance interface and security group attachment procces

### DIFF
--- a/edgecenter/resource_edgecenter_instance.go
+++ b/edgecenter/resource_edgecenter_instance.go
@@ -796,16 +796,16 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, m inter
 				sgsIDsNew := getSecurityGroupsIDs(iNew["security_groups"].([]interface{}))
 				if len(sgsIDsOld) > 0 || len(sgsIDsNew) > 0 {
 					portID := iOld["port_id"].(string)
-					clientSG, err := CreateClient(provider, d, SecurityGroupPoint, VersionPointV1)
+					sgClient, err := CreateClient(provider, d, SecurityGroupPoint, VersionPointV1)
 					if err != nil {
 						return diag.FromErr(err)
 					}
 					removeSGs := getSecurityGroupsDifference(sgsIDsNew, sgsIDsOld)
-					if err := removeSecurityGroupFromInstance(clientSG, client, instanceID, portID, removeSGs); err != nil {
+					if err := removeSecurityGroupFromInstance(sgClient, client, instanceID, portID, removeSGs); err != nil {
 						return diag.FromErr(err)
 					}
 					addSGs := getSecurityGroupsDifference(sgsIDsOld, sgsIDsNew)
-					if err := attachSecurityGroupToInstance(clientSG, client, instanceID, portID, addSGs); err != nil {
+					if err := attachSecurityGroupToInstance(sgClient, client, instanceID, portID, addSGs); err != nil {
 						return diag.FromErr(err)
 					}
 				}


### PR DESCRIPTION
1. Refactored HasChange("interface") then update the instance. There are now 3 cases:
- Same number of interfaces
- New interfaces > old interfaces
- Old interfaces > new interfaces
2. Changed the security group attachment/detachment for HasChange("interface")
3. Moved helper functions from "*_instance.go" file to "utils.go" and left only CRUD operations
4. Added more helper functions for instance cases.