### PR TITLE
fix(CLOUDDEV-650): make mtu unconfigurable attribute.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,6 @@ resource "edgecenter_keypair" "kp" {
 
 resource "edgecenter_network" "network" {
   name       = "network_example"
-  mtu        = 1450
   type       = "vxlan"
   region_id  = 1
   project_id = 1

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -19,7 +19,6 @@ provider "edgecenter" {
 
 resource "edgecenter_network" "network" {
   name       = "network_example"
-  mtu        = 1450
   type       = "vxlan"
   region_id  = 1
   project_id = 1

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -37,7 +37,6 @@ resource "edgecenter_network" "network" {
 - `create_router` (Boolean) Create external router to the network, default true
 - `last_updated` (String) The timestamp of the last update (use with update context).
 - `metadata_map` (Map of String) A map containing metadata, for example tags.
-- `mtu` (Number) Maximum Transmission Unit (MTU) for the network. It determines the maximum packet size that can be transmitted without fragmentation.
 - `project_id` (Number) The uuid of the project. Either 'project_id' or 'project_name' must be specified.
 - `project_name` (String) The name of the project. Either 'project_id' or 'project_name' must be specified.
 - `region_id` (Number) The uuid of the region. Either 'region_id' or 'region_name' must be specified.
@@ -48,6 +47,7 @@ resource "edgecenter_network" "network" {
 
 - `id` (String) The ID of this resource.
 - `metadata_read_only` (List of Object) A list of read-only metadata items, e.g. tags. (see [below for nested schema](#nestedatt--metadata_read_only))
+- `mtu` (Number) Maximum Transmission Unit (MTU) for the network. It determines the maximum packet size that can be transmitted without fragmentation.
 
 <a id="nestedatt--metadata_read_only"></a>
 ### Nested Schema for `metadata_read_only`

--- a/docs/resources/subnet.md
+++ b/docs/resources/subnet.md
@@ -19,7 +19,6 @@ provider "edgecenter" {
 
 resource "edgecenter_network" "network" {
   name       = "network_example"
-  mtu        = 1450
   type       = "vxlan"
   region_id  = 1
   project_id = 1

--- a/edgecenter/resource_edgecenter_network.go
+++ b/edgecenter/resource_edgecenter_network.go
@@ -77,7 +77,6 @@ func resourceNetwork() *schema.Resource {
 			},
 			"mtu": {
 				Type:        schema.TypeInt,
-				Optional:    true,
 				Computed:    true,
 				Description: "Maximum Transmission Unit (MTU) for the network. It determines the maximum packet size that can be transmitted without fragmentation.",
 			},

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -19,7 +19,6 @@ resource "edgecenter_keypair" "kp" {
 
 resource "edgecenter_network" "network" {
   name       = "network_example"
-  mtu        = 1450
   type       = "vxlan"
   region_id  = 1
   project_id = 1

--- a/examples/resources/edgecenter_instance/resource.tf
+++ b/examples/resources/edgecenter_instance/resource.tf
@@ -4,7 +4,6 @@ provider "edgecenter" {
 
 resource "edgecenter_network" "network" {
   name       = "network_example"
-  mtu        = 1450
   type       = "vxlan"
   region_id  = 1
   project_id = 1

--- a/examples/resources/edgecenter_subnet/resource.tf
+++ b/examples/resources/edgecenter_subnet/resource.tf
@@ -4,7 +4,6 @@ provider "edgecenter" {
 
 resource "edgecenter_network" "network" {
   name       = "network_example"
-  mtu        = 1450
   type       = "vxlan"
   region_id  = 1
   project_id = 1


### PR DESCRIPTION
В схеме Network у атрибута mtu убран параметр  Optional, что делает параметр только на чтение.
В документации параметр оставлен в поле Read-Only. 

https://tracker.yandex.ru/CLOUDDEV-650