### PR TITLE
fix(CLOUDDEV-2071): Update edgecentercloud-go to v2.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ### IDEs
 .vscode
 .idea
+.fleet
 .DS_Store
 
 ### terraform

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Edge-Center/edgecenter-storage-sdk-go v0.2.1
 	github.com/Edge-Center/edgecentercdn-go v0.1.23
 	github.com/Edge-Center/edgecentercloud-go v0.1.11
-	github.com/Edge-Center/edgecentercloud-go/v2 v2.3.0
+	github.com/Edge-Center/edgecentercloud-go/v2 v2.4.1
 	github.com/Edge-Center/edgecenterprotection-go v0.1.6
 	github.com/connerdouglass/go-retry v1.0.1
 	github.com/hashicorp/go-cty v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -7,14 +7,12 @@ github.com/Edge-Center/edgecenter-dns-sdk-go v0.1.3 h1:k36RWZ+dteXLMiEsu/KiSFSaN
 github.com/Edge-Center/edgecenter-dns-sdk-go v0.1.3/go.mod h1:xWN2LYVokamADMRz1cPhOrYX/NlxiDJp9tjBumHU5G8=
 github.com/Edge-Center/edgecenter-storage-sdk-go v0.2.1 h1:retVB8Nh71mIoanxSGXJO/97+Z7FNzCiqujlck2NFw4=
 github.com/Edge-Center/edgecenter-storage-sdk-go v0.2.1/go.mod h1:XTee8a/zrhJmNKQIx2TMkl+aBryyy2sXDaByHj2rwMk=
-github.com/Edge-Center/edgecentercdn-go v0.1.21 h1:Erb11iftEyf7ObCWiT4TvhM1U2B9QDZwzGc/UtHLCrE=
-github.com/Edge-Center/edgecentercdn-go v0.1.21/go.mod h1:AY78xH6xIfuRu9WEl5EejslJygNFhlp+xEwJl3jKt2M=
 github.com/Edge-Center/edgecentercdn-go v0.1.23 h1:5y2WLnEZvfKzrXUPpT46Egt9KjNNDelS6AlgCExZEOQ=
 github.com/Edge-Center/edgecentercdn-go v0.1.23/go.mod h1:AY78xH6xIfuRu9WEl5EejslJygNFhlp+xEwJl3jKt2M=
 github.com/Edge-Center/edgecentercloud-go v0.1.11 h1:00h5o/71lEoSdU1B4AWmviuOfO28P6nsRP+afjIsW80=
 github.com/Edge-Center/edgecentercloud-go v0.1.11/go.mod h1:kmXGtx0lL1ib+SPfJe/uIAyDHamquAvqiftoLSyhxF8=
-github.com/Edge-Center/edgecentercloud-go/v2 v2.3.0 h1:Kvc9Jv8qAeVHefTCZo97LhCAC3spIDrjbmvpS/mx5b8=
-github.com/Edge-Center/edgecentercloud-go/v2 v2.3.0/go.mod h1:ukw29nT+EKFe+qrPsInTwE9Ok35KC0hUnZ3bKwfIEcg=
+github.com/Edge-Center/edgecentercloud-go/v2 v2.4.1 h1:4VSRD6j4C6GMYAuIZa1nmkSsvBjiLhfMnAs8jSmhYTw=
+github.com/Edge-Center/edgecentercloud-go/v2 v2.4.1/go.mod h1:ukw29nT+EKFe+qrPsInTwE9Ok35KC0hUnZ3bKwfIEcg=
 github.com/Edge-Center/edgecenterprotection-go v0.1.6 h1:VTvpFppJr85P74mWsXPll84LF5Xv9sBXvhEmWSDLAco=
 github.com/Edge-Center/edgecenterprotection-go v0.1.6/go.mod h1:AtcLxO2MNM1boGknY593k09EVfo0JAmRL60klHC1kt4=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=


### PR DESCRIPTION
[CLOUDDEV-2071](https://tasks.edgecenter.ru/browse/CLOUDDEV-2071)