### PR TITLE
fix(TF-20): [router] handle empty routes for router creation

### DIFF
--- a/edgecenter/resource_edgecenter_router.go
+++ b/edgecenter/resource_edgecenter_router.go
@@ -197,6 +197,7 @@ func resourceRouterCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	rs := d.Get("routes")
+	createOpts.Routes = make([]edgecloudV2.HostRoute, 0)
 	routesSet := rs.(*schema.Set)
 	if routesSet.Len() > 0 {
 		routes, err := extractHostRoutesMapV2(routesSet.List())


### PR DESCRIPTION
Expected behavior: when routes are not provided, send routes: []
or don't send the field at all. Now initializing routes as empty array.