### PR TITLE
fix(TF-53): [instance] use set for interface security_groups

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -205,7 +205,7 @@ Optional:
 - `order` (Number) Order of attaching interface
 - `port_id` (String) required if type is  'reserved_fixed_ip'
 - `port_security_disabled` (Boolean)
-- `security_groups` (List of String) list of security group IDs
+- `security_groups` (Set of String) set of security group IDs
 - `subnet_id` (String) Required if type is 'subnet'.
 - `type` (String) Available value is 'subnet', 'any_subnet', 'external', 'reserved_fixed_ip'
 

--- a/edgecenter/resource_edgecenter_instance.go
+++ b/edgecenter/resource_edgecenter_instance.go
@@ -218,9 +218,9 @@ func resourceInstance() *schema.Resource {
 							Optional:    true,
 						},
 						"security_groups": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Optional:    true,
-							Description: "list of security group IDs",
+							Description: "set of security group IDs",
 							Elem:        &schema.Schema{Type: schema.TypeString},
 						},
 						"ip_address": {
@@ -807,8 +807,8 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, m inter
 				iOld := item.(map[string]interface{})
 				iNew := ifsNewSlice[idx].(map[string]interface{})
 
-				sgsIDsOld := getSecurityGroupsIDsV2(iOld["security_groups"].([]interface{}))
-				sgsIDsNew := getSecurityGroupsIDsV2(iNew["security_groups"].([]interface{}))
+				sgsIDsOld := getSecurityGroupsIDsV2(getNestedSetList(iOld["security_groups"]))
+				sgsIDsNew := getSecurityGroupsIDsV2(getNestedSetList(iNew["security_groups"]))
 				if len(sgsIDsOld) > 0 || len(sgsIDsNew) > 0 {
 					portID := iOld["port_id"].(string)
 					removeSGs := getSecurityGroupsDifferenceV2(sgsIDsNew, sgsIDsOld)
@@ -838,8 +838,8 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, m inter
 				iOld := item.(map[string]interface{})
 				iNew := ifsNewSlice[idx].(map[string]interface{})
 
-				sgsIDsOld := getSecurityGroupsIDsV2(iOld["security_groups"].([]interface{}))
-				sgsIDsNew := getSecurityGroupsIDsV2(iNew["security_groups"].([]interface{}))
+				sgsIDsOld := getSecurityGroupsIDsV2(getNestedSetList(iOld["security_groups"]))
+				sgsIDsNew := getSecurityGroupsIDsV2(getNestedSetList(iNew["security_groups"]))
 				if len(sgsIDsOld) > 0 || len(sgsIDsNew) > 0 {
 					portID := iOld["port_id"].(string)
 					removeSGs := getSecurityGroupsDifferenceV2(sgsIDsNew, sgsIDsOld)
@@ -877,8 +877,8 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, m inter
 				iOld := item.(map[string]interface{})
 				iNew := ifsNewSlice[idx].(map[string]interface{})
 
-				sgsIDsOld := getSecurityGroupsIDsV2(iOld["security_groups"].([]interface{}))
-				sgsIDsNew := getSecurityGroupsIDsV2(iNew["security_groups"].([]interface{}))
+				sgsIDsOld := getSecurityGroupsIDsV2(getNestedSetList(iOld["security_groups"]))
+				sgsIDsNew := getSecurityGroupsIDsV2(getNestedSetList(iNew["security_groups"]))
 				if len(sgsIDsOld) > 0 || len(sgsIDsNew) > 0 {
 					portID := iOld["port_id"].(string)
 					removeSGs := getSecurityGroupsDifferenceV2(sgsIDsNew, sgsIDsOld)

--- a/edgecenter/utils_instance.go
+++ b/edgecenter/utils_instance.go
@@ -104,6 +104,19 @@ type OrderedInterfaceOpts struct {
 	Order int
 }
 
+func getNestedSetList(value interface{}) []interface{} {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case []interface{}:
+		return typed
+	case *schema.Set:
+		return typed.List()
+	default:
+		return nil
+	}
+}
+
 // decodeInstanceInterfaceOpts decodes the interface and returns InstanceInterface with FloatingIP.
 func decodeInstanceInterfaceOpts(iFaceMap map[string]interface{}) edgecloudV2.InstanceInterface {
 	iFace := edgecloudV2.InstanceInterface{
@@ -128,7 +141,7 @@ func decodeInstanceInterfaceOpts(iFaceMap map[string]interface{}) edgecloudV2.In
 	if rawSgsID == nil {
 		return iFace
 	}
-	rawSgsIDList := iFaceMap["security_groups"].([]interface{})
+	rawSgsIDList := getNestedSetList(rawSgsID)
 	sgs := make([]edgecloudV2.ID, len(rawSgsIDList))
 	for i, sgID := range rawSgsIDList {
 		sgs[i] = edgecloudV2.ID{ID: sgID.(string)}
@@ -464,7 +477,7 @@ func attachInterfaceToInstanceV2(ctx context.Context, client *edgecloudV2.Client
 	}
 	secGroups := iface["security_groups"]
 	if secGroups != nil {
-		opts.SecurityGroups = getSecurityGroupsIDsV2(secGroups.([]interface{}))
+		opts.SecurityGroups = getSecurityGroupsIDsV2(getNestedSetList(secGroups))
 	} else {
 		opts.SecurityGroups = []edgecloudV2.ID{}
 	}
@@ -830,7 +843,7 @@ func validateInterfaceAttrs(d *schema.ResourceData) diag.Diagnostics {
 			isPortSecDisabled = v.(bool)
 		}
 		if v, ok := iNew["security_groups"]; ok {
-			secGroups := v.([]interface{})
+			secGroups := getNestedSetList(v)
 			if len(secGroups) != 0 {
 				isSecGroupExists = true
 			}


### PR DESCRIPTION
edgecenter_instance: change interface.security_groups from TypeList to TypeSet
Instance create/update/validation: handle nested security_groups as set
Fix false diffs when the same security group is used across multiple interfaces
Manual repro: repeated terraform plan is empty after apply