### PR TITLE
fix(TF-22): [baremetal] add interface subnet-to-network validation

### DIFF
--- a/edgecenter/resource_edgecenter_baremetal.go
+++ b/edgecenter/resource_edgecenter_baremetal.go
@@ -286,21 +286,15 @@ func resourceBmInstanceCreate(ctx context.Context, d *schema.ResourceData, m int
 	interfaceOptsList := make([]edgecloudV2.BareMetalInterfaceOpts, len(ifs))
 	for i, iFace := range ifs {
 		raw := iFace.(map[string]interface{})
+		if err := validateBaremetalInterface(ctx, clientV2, raw); err != nil {
+			return diag.FromErr(err)
+		}
+
 		interfaceOpts := edgecloudV2.BareMetalInterfaceOpts{
 			Type:      edgecloudV2.InterfaceType(raw["type"].(string)),
 			NetworkID: raw["network_id"].(string),
 			SubnetID:  raw["subnet_id"].(string),
 			PortID:    raw["port_id"].(string),
-		}
-
-		if interfaceOpts.NetworkID != "" {
-			network, _, err := clientV2.Networks.Get(ctx, interfaceOpts.NetworkID)
-			if err != nil {
-				return diag.Errorf("Error getting network information: %s", err)
-			}
-			if network.Type == "vxlan" {
-				return diag.Errorf("VxLAN networks are not supported for baremetal instances")
-			}
 		}
 
 		fipSource := raw["fip_source"].(string)
@@ -627,6 +621,13 @@ func resourceBmInstanceUpdate(ctx context.Context, d *schema.ResourceData, m int
 
 		ifsOld := ifsOldRaw.([]interface{})
 		ifsNew := ifsNewRaw.([]interface{})
+
+		for _, i := range ifsNew {
+			iface := i.(map[string]interface{})
+			if err := validateBaremetalInterface(ctx, clientV2, iface); err != nil {
+				return diag.FromErr(err)
+			}
+		}
 
 		for _, i := range ifsOld {
 			iface := i.(map[string]interface{})

--- a/edgecenter/utils_instance.go
+++ b/edgecenter/utils_instance.go
@@ -449,6 +449,36 @@ func detachInterfaceFromInstanceV2(ctx context.Context, client *edgecloudV2.Clie
 	return nil
 }
 
+// validateBaremetalInterface validates that a baremetal interface uses a supported network
+// and that the subnet belongs to the specified network.
+func validateBaremetalInterface(ctx context.Context, client *edgecloudV2.Client, iface map[string]interface{}) error {
+	iType := edgecloudV2.InterfaceType(iface["type"].(string))
+	networkID := iface["network_id"].(string)
+	subnetID := iface["subnet_id"].(string)
+
+	if networkID != "" {
+		network, _, err := client.Networks.Get(ctx, networkID)
+		if err != nil {
+			return fmt.Errorf("error getting network information: %w", err)
+		}
+		if network.Type == "vxlan" {
+			return fmt.Errorf("VxLAN networks are not supported for baremetal instances")
+		}
+	}
+
+	if iType == edgecloudV2.InterfaceTypeSubnet && subnetID != "" && networkID != "" {
+		subnet, _, err := client.Subnetworks.Get(ctx, subnetID)
+		if err != nil {
+			return fmt.Errorf("error getting subnet information: %w", err)
+		}
+		if subnet.NetworkID != networkID {
+			return fmt.Errorf("subnet %s does not belong to network %s", subnetID, networkID)
+		}
+	}
+
+	return nil
+}
+
 // attachInterfaceToInstance attach interface to instance.
 func attachInterfaceToInstanceV2(ctx context.Context, client *edgecloudV2.Client, instanceID string, iface map[string]interface{}) error {
 	iType := edgecloudV2.InterfaceType(iface["type"].(string))


### PR DESCRIPTION
Validate baremetal interface subnet/network relation
Fail update when subnet belongs to another network