### PR TITLE
fix(TF-126) [cdn_shielding] fix false diff

### DIFF
--- a/edgecenter/resource_edgecenter_cdn_shielding.go
+++ b/edgecenter/resource_edgecenter_cdn_shielding.go
@@ -53,8 +53,10 @@ func resourceCDNShieldingRead(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
-	err = d.Set("shielding_pop", result.ShieldingPop)
-	if err != nil {
+	if err = d.Set("shielding_pop", result.ShieldingPop); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("resource_id", resourceID); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
Fix missing resource_id in state after importing edgecenter_cdn_shielding.
Read now sets resource_id, eliminating the false diff in terraform plan.