### PR TITLE
fix(TF-128) [MKAAS] normalize K8s version when reading cluster state

### DIFF
--- a/edgecenter/data_source_edgecenter_mkaas_cluster.go
+++ b/edgecenter/data_source_edgecenter_mkaas_cluster.go
@@ -155,7 +155,7 @@ func dataSourceMKaaSClusterRead(ctx context.Context, d *schema.ResourceData, m i
 		"node_count":  cluster.ControlPlane.NodeCount,
 		"volume_size": cluster.ControlPlane.VolumeSize,
 		"volume_type": string(cluster.ControlPlane.VolumeType),
-		"version":     cluster.ControlPlane.Version,
+		"version":     normalizeVersion(cluster.ControlPlane.Version),
 	}
 	_ = d.Set("control_plane", []interface{}{cp})
 

--- a/edgecenter/resource_edgecenter_mkaas_cluster.go
+++ b/edgecenter/resource_edgecenter_mkaas_cluster.go
@@ -294,7 +294,7 @@ func resourceMKaaSClusterRead(ctx context.Context, d *schema.ResourceData, m int
 		MKaaSNodeCountField:      cluster.ControlPlane.NodeCount,
 		MKaaSVolumeSizeField:     cluster.ControlPlane.VolumeSize,
 		MKaaSVolumeTypeField:     string(cluster.ControlPlane.VolumeType),
-		MKaaSClusterVersionField: cluster.ControlPlane.Version,
+		MKaaSClusterVersionField: normalizeVersion(cluster.ControlPlane.Version),
 	}
 	_ = d.Set(MKaaSClusterControlPlaneField, []interface{}{cp})
 	_ = d.Set(MKaaSClusterInternalIPField, cluster.InternalIP)

--- a/edgecenter/utils_mkaas.go
+++ b/edgecenter/utils_mkaas.go
@@ -3,6 +3,7 @@ package edgecenter
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -192,6 +193,14 @@ func mkaasPoolUnsupportedUpdateChanges(d *schema.ResourceData) []string {
 	}
 
 	return unsupported
+}
+
+func normalizeVersion(fullVersion string) string {
+	parts := strings.SplitN(fullVersion, ".", 3)
+	if len(parts) >= 2 {
+		return strings.Join(parts[:2], ".")
+	}
+	return fullVersion
 }
 
 func resolveK8sVersion(shortVersion string) string {


### PR DESCRIPTION
fix: normalize K8s version when reading cluster state