### PR TITLE
fix(TF-147)[dbaas]: support clearing name and description on cluster update

### DIFF
--- a/edgecenter/resource_edgecenter_dbaas_cluster.go
+++ b/edgecenter/resource_edgecenter_dbaas_cluster.go
@@ -333,13 +333,12 @@ func resourceDBaaSClusterUpdate(ctx context.Context, d *schema.ResourceData, m i
 
 	updateOpts := edgecloudV2.DBaaSClusterUpdateRequest{}
 
-	if d.HasChange(NameField) {
-		name := d.Get(NameField).(string)
-		updateOpts.Name = name
-	}
+	name := d.Get(NameField).(string)
+	updateOpts.Name = &name
+
 	if d.HasChange(DescriptionField) {
 		desc := d.Get(DescriptionField).(string)
-		updateOpts.Description = desc
+		updateOpts.Description = &desc
 	}
 	if d.HasChange(FlavorField) {
 		flavor := d.Get(FlavorField).(string)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Edge-Center/edgecenter-storage-sdk-go v0.2.1
 	github.com/Edge-Center/edgecentercdn-go v0.2.7
 	github.com/Edge-Center/edgecentercloud-go v0.1.11
-	github.com/Edge-Center/edgecentercloud-go/v2 v2.6.5
+	github.com/Edge-Center/edgecentercloud-go/v2 v2.6.7
 	github.com/Edge-Center/edgecenteredgemon-go v0.1.0
 	github.com/Edge-Center/edgecenterprotection-go v0.1.7
 	github.com/connerdouglass/go-retry v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/Edge-Center/edgecentercdn-go v0.2.7 h1:CJs5wDFlN5PsvTOobUGndIsHBRKzzv
 github.com/Edge-Center/edgecentercdn-go v0.2.7/go.mod h1:aF3j7elRw9jmMc2BhdhKICj10En0pdO/JNWZ4BtICmQ=
 github.com/Edge-Center/edgecentercloud-go v0.1.11 h1:00h5o/71lEoSdU1B4AWmviuOfO28P6nsRP+afjIsW80=
 github.com/Edge-Center/edgecentercloud-go v0.1.11/go.mod h1:kmXGtx0lL1ib+SPfJe/uIAyDHamquAvqiftoLSyhxF8=
-github.com/Edge-Center/edgecentercloud-go/v2 v2.6.5 h1:EnloDtdBfw/IPiR+bYlzBnwGyfZ5vfQ0PyHpYJtIabI=
-github.com/Edge-Center/edgecentercloud-go/v2 v2.6.5/go.mod h1:aLN+G5rA8umwnIJ5U+f/cWNWdhhFRgWY0DZ6VyFXT6M=
+github.com/Edge-Center/edgecentercloud-go/v2 v2.6.7 h1:UbjXx/4NrswqTho7tWBCeg0jAyedLKaFh4y/ztlczpE=
+github.com/Edge-Center/edgecentercloud-go/v2 v2.6.7/go.mod h1:aLN+G5rA8umwnIJ5U+f/cWNWdhhFRgWY0DZ6VyFXT6M=
 github.com/Edge-Center/edgecenteredgemon-go v0.1.0 h1:+oyQK4o6tSpUC1R0QEp/U9/5YtImt+Klmf/ec2yngt4=
 github.com/Edge-Center/edgecenteredgemon-go v0.1.0/go.mod h1:+X+bLKzx+lr1C//4LvbKe9ZXMvoteWsHeAZ43fjJWcI=
 github.com/Edge-Center/edgecenterprotection-go v0.1.7 h1:f9AF/B8+5a9OqbF5lhegKSClGvPvRG18pqZRuDJPSFI=


### PR DESCRIPTION
Bump edgecentercloud-go/v2 to v2.6.7 (Name/Description changed to *string).
Always send name in update body; use *string for description to distinguish
clearing (empty) from not changing (nil).