### PR TITLE
feat(TF-118)[dbaas]: add access control support for DBaaS clusters

### DIFF
--- a/docs/data-sources/dbaas_clusters.md
+++ b/docs/data-sources/dbaas_clusters.md
@@ -42,6 +42,7 @@ output "view" {
 
 ### Read-Only
 
+- `access` (List of Object) (see [below for nested schema](#nestedatt--access))
 - `connection_info` (List of Object) (see [below for nested schema](#nestedatt--connection_info))
 - `created_at` (String)
 - `dbms` (List of Object) (see [below for nested schema](#nestedatt--dbms))
@@ -53,6 +54,15 @@ output "view" {
 - `task_id` (String)
 - `updated_at` (String)
 - `volume` (List of Object) (see [below for nested schema](#nestedatt--volume))
+
+<a id="nestedatt--access"></a>
+### Nested Schema for `access`
+
+Read-Only:
+
+- `allowed_cidrs` (Set of String)
+- `is_public` (Boolean)
+
 
 <a id="nestedatt--connection_info"></a>
 ### Nested Schema for `connection_info`

--- a/docs/resources/dbaas_cluster.md
+++ b/docs/resources/dbaas_cluster.md
@@ -38,6 +38,11 @@ resource "edgecenter_dbaas_cluster" "example" {
     network_id = "6bf878c1-1ce4-47c3-a39b-6b5f1d79bf25"
     subnet_id  = "dc3a3ea9-86ae-47ad-a8e8-79df0ce04839"
   }
+
+  access {
+    is_public     = true
+    allowed_cidrs = ["192.168.23.0/24"]
+  }
 }
 ```
 
@@ -54,6 +59,7 @@ resource "edgecenter_dbaas_cluster" "example" {
 
 ### Optional
 
+- `access` (Block List, Max: 1) The access control settings for the DBaaS cluster. (see [below for nested schema](#nestedblock--access))
 - `description` (String) The description of the DBaaS cluster.
 - `high_availability` (Boolean) Enable high availability for the cluster.
 - `project_id` (Number) The uuid of the project. Either 'project_id' or 'project_name' must be specified.
@@ -96,6 +102,15 @@ Required:
 
 - `volume_size` (Number) The size of the volume in GB.
 - `volume_type` (String) The type of the volume (e.g., db_standard).
+
+
+<a id="nestedblock--access"></a>
+### Nested Schema for `access`
+
+Optional:
+
+- `allowed_cidrs` (Set of String) The list of allowed CIDRs for public access to the cluster.
+- `is_public` (Boolean) Whether the cluster public endpoint is enabled.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/edgecenter/integrationtest/support/dbaas/mock/DBaaSService.go
+++ b/edgecenter/integrationtest/support/dbaas/mock/DBaaSService.go
@@ -404,6 +404,45 @@ func (_m *DBaaSService) ClusterUpdate(_a0 context.Context, _a1 string, _a2 edgec
 	return r0, r1, r2
 }
 
+// ClusterUpdateAccessControl provides a mock function with given fields: _a0, _a1, _a2
+func (_m *DBaaSService) ClusterUpdateAccessControl(_a0 context.Context, _a1 string, _a2 edgecloud.DBaaSClusterAccessControlUpdateRequest) (*edgecloud.TaskResponse, *edgecloud.Response, error) {
+	ret := _m.Called(_a0, _a1, _a2)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ClusterUpdateAccessControl")
+	}
+
+	var r0 *edgecloud.TaskResponse
+	var r1 *edgecloud.Response
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, edgecloud.DBaaSClusterAccessControlUpdateRequest) (*edgecloud.TaskResponse, *edgecloud.Response, error)); ok {
+		return rf(_a0, _a1, _a2)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, edgecloud.DBaaSClusterAccessControlUpdateRequest) *edgecloud.TaskResponse); ok {
+		r0 = rf(_a0, _a1, _a2)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*edgecloud.TaskResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, edgecloud.DBaaSClusterAccessControlUpdateRequest) *edgecloud.Response); ok {
+		r1 = rf(_a0, _a1, _a2)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*edgecloud.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, string, edgecloud.DBaaSClusterAccessControlUpdateRequest) error); ok {
+		r2 = rf(_a0, _a1, _a2)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // ClustersList provides a mock function with given fields: _a0, _a1
 func (_m *DBaaSService) ClustersList(_a0 context.Context, _a1 *edgecloud.DBaaSClusterListOptions) ([]edgecloud.DBaaSCluster, *edgecloud.Response, error) {
 	ret := _m.Called(_a0, _a1)

--- a/edgecenter/provider.go
+++ b/edgecenter/provider.go
@@ -186,10 +186,14 @@ const (
 	DBaaSVolumeSizeField = "volume_size"
 	DBaaSVolumeTypeField = "volume_type"
 
+	DBaaSClusterAllowedCIDRsField = "allowed_cidrs"
+	DBaaSClusterIsPublicField     = "is_public"
+
 	DBaaSClusterHostField = "host"
 	DBaaSClusterPortField = "port"
 
 	DBaaSClusterConnectionField = "connection_info"
+	DBaaSClusterAccessField     = "access"
 
 	DBaaSDatabaseEncodingField = "encoding"
 	DBaaSDatabaseLocaleField   = "locale"

--- a/edgecenter/services/dbaas/access.go
+++ b/edgecenter/services/dbaas/access.go
@@ -1,0 +1,168 @@
+package dbaas
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	edgecloudV2 "github.com/Edge-Center/edgecentercloud-go/v2"
+	"github.com/Edge-Center/terraform-provider-edgecenter/edgecenter"
+)
+
+const dbaasClusterAccessPollInterval = 5 * time.Second
+
+func expandDBaaSClusterAccess(raw interface{}) *edgecloudV2.DBaaSClusterAccess {
+	accessList, ok := raw.([]interface{})
+	if !ok || len(accessList) == 0 || accessList[0] == nil {
+		return nil
+	}
+
+	accessMap, ok := accessList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return &edgecloudV2.DBaaSClusterAccess{
+		AllowedCIDRs: expandStringSet(accessMap[edgecenter.DBaaSClusterAllowedCIDRsField]),
+		IsPublic:     accessMap[edgecenter.DBaaSClusterIsPublicField].(bool),
+	}
+}
+
+func expandDBaaSClusterAccessControlUpdateRequest(raw interface{}) edgecloudV2.DBaaSClusterAccessControlUpdateRequest {
+	access := expandDBaaSClusterAccess(raw)
+	if access == nil {
+		emptyCIDRs := []string{}
+		isPublic := false
+
+		return edgecloudV2.DBaaSClusterAccessControlUpdateRequest{
+			AllowedCIDRs: &emptyCIDRs,
+			IsPublic:     &isPublic,
+		}
+	}
+
+	allowedCIDRs := access.AllowedCIDRs
+	isPublic := access.IsPublic
+
+	return edgecloudV2.DBaaSClusterAccessControlUpdateRequest{
+		AllowedCIDRs: &allowedCIDRs,
+		IsPublic:     &isPublic,
+	}
+}
+
+func flattenDBaaSClusterAccess(access *edgecloudV2.DBaaSClusterAccess) []interface{} {
+	if access == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			edgecenter.DBaaSClusterAllowedCIDRsField: schema.NewSet(schema.HashString, stringSliceToInterfaceSlice(access.AllowedCIDRs)),
+			edgecenter.DBaaSClusterIsPublicField:     access.IsPublic,
+		},
+	}
+}
+
+func flattenDBaaSClusterConnection(connection *edgecloudV2.DBaaSConnection) []interface{} {
+	if connection == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			edgecenter.DBaaSClusterHostField: connection.Host,
+			edgecenter.DBaaSClusterPortField: connection.Port,
+		},
+	}
+}
+
+func expandStringSet(raw interface{}) []string {
+	set, ok := raw.(*schema.Set)
+	if !ok || set == nil {
+		return nil
+	}
+
+	values := set.List()
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = append(result, value.(string))
+	}
+
+	return result
+}
+
+func waitDBaaSClusterAccessState(
+	ctx context.Context,
+	client *edgecloudV2.Client,
+	clusterID string,
+	expectedAccess *edgecloudV2.DBaaSClusterAccess,
+	timeout time.Duration,
+) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(dbaasClusterAccessPollInterval)
+	defer ticker.Stop()
+
+	for {
+		cluster, _, err := client.DBaaS.ClusterGet(ctx, clusterID)
+		if err != nil {
+			return fmt.Errorf("get DBaaS cluster %s: %w", clusterID, err)
+		}
+
+		if isDBaaSClusterAccessReady(cluster, expectedAccess) {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("DBaaS cluster access state did not converge within timeout")
+		case <-ticker.C:
+		}
+	}
+}
+
+func isDBaaSClusterAccessReady(cluster *edgecloudV2.DBaaSCluster, expectedAccess *edgecloudV2.DBaaSClusterAccess) bool {
+	if cluster == nil || cluster.Access == nil {
+		return false
+	}
+
+	if cluster.Access.IsPublic != expectedAccess.IsPublic {
+		return false
+	}
+
+	if !stringSetsEqual(cluster.Access.AllowedCIDRs, expectedAccess.AllowedCIDRs) {
+		return false
+	}
+
+	return true
+}
+
+func stringSetsEqual(actual, expected []string) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+
+	actualSet := make(map[string]struct{}, len(actual))
+	for _, value := range actual {
+		actualSet[value] = struct{}{}
+	}
+
+	for _, value := range expected {
+		if _, ok := actualSet[value]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func stringSliceToInterfaceSlice(values []string) []interface{} {
+	result := make([]interface{}, 0, len(values))
+	for _, value := range values {
+		result = append(result, value)
+	}
+
+	return result
+}

--- a/edgecenter/services/dbaas/cluster.go
+++ b/edgecenter/services/dbaas/cluster.go
@@ -158,6 +158,28 @@ func resourceDBaaSCluster() *schema.Resource {
 					},
 				},
 			},
+			edgecenter.DBaaSClusterAccessField: {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "The access control settings for the DBaaS cluster.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						edgecenter.DBaaSClusterAllowedCIDRsField: {
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "The list of allowed CIDRs for public access to the cluster.",
+						},
+						edgecenter.DBaaSClusterIsPublicField: {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Whether the cluster public endpoint is enabled.",
+						},
+					},
+				},
+			},
 			edgecenter.StatusField: {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -242,11 +264,19 @@ func resourceDBaaSClusterCreate(ctx context.Context, d *schema.ResourceData, m i
 		}
 	}
 
+	createOpts.Access = expandDBaaSClusterAccess(d.Get(edgecenter.DBaaSClusterAccessField))
+
 	tflog.Debug(ctx, fmt.Sprintf("DBaaS cluster create options: %+v", createOpts))
 
 	cluster, err := utilV2.CreateDBaaSClusterAndWait(ctx, clientV2, createOpts, DBaaSClusterCreateTimeout)
 	if err != nil {
 		return diag.Errorf("error from creating DBaaS cluster: %s", err)
+	}
+
+	if createOpts.Access != nil {
+		if err = waitDBaaSClusterAccessState(ctx, clientV2, cluster.ID, createOpts.Access, DBaaSClusterCreateTimeout); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	d.SetId(cluster.ID)
@@ -312,12 +342,11 @@ func resourceDBaaSClusterRead(ctx context.Context, d *schema.ResourceData, m int
 		_ = d.Set("interface", []interface{}{iface})
 	}
 
+	if cluster.Access != nil {
+		_ = d.Set(edgecenter.DBaaSClusterAccessField, flattenDBaaSClusterAccess(cluster.Access))
+	}
 	if cluster.Connection != nil {
-		conn := map[string]interface{}{
-			edgecenter.DBaaSClusterHostField: cluster.Connection.Host,
-			edgecenter.DBaaSClusterPortField: cluster.Connection.Port,
-		}
-		_ = d.Set(edgecenter.DBaaSClusterConnectionField, []interface{}{conn})
+		_ = d.Set(edgecenter.DBaaSClusterConnectionField, flattenDBaaSClusterConnection(cluster.Connection))
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("DBaaS cluster read complete: %+v", cluster))
@@ -335,6 +364,7 @@ func resourceDBaaSClusterUpdate(ctx context.Context, d *schema.ResourceData, m i
 	}
 
 	updateOpts := edgecloudV2.DBaaSClusterUpdateRequest{}
+	var clusterChanged bool
 
 	name := d.Get(edgecenter.NameField).(string)
 	updateOpts.Name = &name
@@ -342,10 +372,12 @@ func resourceDBaaSClusterUpdate(ctx context.Context, d *schema.ResourceData, m i
 	if d.HasChange(edgecenter.DescriptionField) {
 		desc := d.Get(edgecenter.DescriptionField).(string)
 		updateOpts.Description = &desc
+		clusterChanged = true
 	}
 	if d.HasChange(edgecenter.FlavorField) {
 		flavor := d.Get(edgecenter.FlavorField).(string)
 		updateOpts.Flavor = flavor
+		clusterChanged = true
 	}
 
 	if d.HasChange("volume") {
@@ -357,20 +389,53 @@ func resourceDBaaSClusterUpdate(ctx context.Context, d *schema.ResourceData, m i
 					Size: vol[edgecenter.DBaaSVolumeSizeField].(int),
 					Type: edgecloudV2.VolumeType(vol[edgecenter.DBaaSVolumeTypeField].(string)),
 				}
+				clusterChanged = true
 			}
 		}
 	}
 
-	tasks, _, err := clientV2.DBaaS.ClusterUpdate(ctx, clusterID, updateOpts)
-	if err != nil {
-		return diag.FromErr(err)
+	if clusterChanged {
+		tasks, _, err := clientV2.DBaaS.ClusterUpdate(ctx, clusterID, updateOpts)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if len(tasks.Tasks) > 0 {
+			taskID := tasks.Tasks[0]
+			err = utilV2.WaitForTaskComplete(ctx, clientV2, taskID, DBaaSClusterUpdateTimeout)
+			if err != nil {
+				tflog.Warn(ctx, fmt.Sprintf("[WARN] task %s not found, assuming update completed: %s", taskID, err))
+			}
+		}
 	}
 
-	if len(tasks.Tasks) > 0 {
-		taskID := tasks.Tasks[0]
-		err = utilV2.WaitForTaskComplete(ctx, clientV2, taskID, DBaaSClusterUpdateTimeout)
+	if d.HasChange(edgecenter.DBaaSClusterAccessField) {
+		access := expandDBaaSClusterAccess(d.Get(edgecenter.DBaaSClusterAccessField))
+		accessUpdateOpts := expandDBaaSClusterAccessControlUpdateRequest(d.Get(edgecenter.DBaaSClusterAccessField))
+		if access == nil {
+			access = &edgecloudV2.DBaaSClusterAccess{}
+		}
+
+		tasks, _, err := clientV2.DBaaS.ClusterUpdateAccessControl(ctx, clusterID, accessUpdateOpts)
 		if err != nil {
-			tflog.Warn(ctx, fmt.Sprintf("[WARN] task %s not found, assuming update completed: %s", taskID, err))
+			return diag.FromErr(err)
+		}
+
+		if len(tasks.Tasks) > 0 {
+			taskID := tasks.Tasks[0]
+			err = utilV2.WaitForTaskComplete(ctx, clientV2, taskID, DBaaSClusterUpdateTimeout)
+			if err != nil {
+				tflog.Warn(ctx, fmt.Sprintf("[WARN] task %s not found, assuming access control update completed: %s", taskID, err))
+			}
+		}
+
+		_, err = utilV2.WaitDBaaSClusterStatusHealthy(ctx, clientV2, clusterID, DBaaSClusterUpdateTimeout)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if err = waitDBaaSClusterAccessState(ctx, clientV2, clusterID, access, DBaaSClusterUpdateTimeout); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 

--- a/edgecenter/services/dbaas/data_source_clusters.go
+++ b/edgecenter/services/dbaas/data_source_clusters.go
@@ -102,6 +102,23 @@ func dataSourceDBaaSClusters() *schema.Resource {
 					},
 				},
 			},
+			edgecenter.DBaaSClusterAccessField: {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						edgecenter.DBaaSClusterAllowedCIDRsField: {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						edgecenter.DBaaSClusterIsPublicField: {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
 			edgecenter.DBaaSClusterConnectionField: {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -229,12 +246,11 @@ func dataSourceDBaaSClustersRead(ctx context.Context, d *schema.ResourceData, m 
 		_ = d.Set("interface", []interface{}{iface})
 	}
 
+	if cluster.Access != nil {
+		_ = d.Set(edgecenter.DBaaSClusterAccessField, flattenDBaaSClusterAccess(cluster.Access))
+	}
 	if cluster.Connection != nil {
-		conn := map[string]interface{}{
-			edgecenter.DBaaSClusterHostField: cluster.Connection.Host,
-			edgecenter.DBaaSClusterPortField: cluster.Connection.Port,
-		}
-		_ = d.Set(edgecenter.DBaaSClusterConnectionField, []interface{}{conn})
+		_ = d.Set(edgecenter.DBaaSClusterConnectionField, flattenDBaaSClusterConnection(cluster.Connection))
 	}
 
 	_ = d.Set(edgecenter.CreatedAtField, cluster.CreatedAt)

--- a/examples/resources/edgecenter_dbaas_cluster/resource.tf
+++ b/examples/resources/edgecenter_dbaas_cluster/resource.tf
@@ -23,4 +23,9 @@ resource "edgecenter_dbaas_cluster" "example" {
     network_id = "6bf878c1-1ce4-47c3-a39b-6b5f1d79bf25"
     subnet_id  = "dc3a3ea9-86ae-47ad-a8e8-79df0ce04839"
   }
+
+  access {
+    is_public     = true
+    allowed_cidrs = ["192.168.23.0/24"]
+  }
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Edge-Center/edgecenter-storage-sdk-go v0.2.1
 	github.com/Edge-Center/edgecentercdn-go v0.2.7
 	github.com/Edge-Center/edgecentercloud-go v0.1.11
-	github.com/Edge-Center/edgecentercloud-go/v2 v2.6.7
+	github.com/Edge-Center/edgecentercloud-go/v2 v2.7.0
 	github.com/Edge-Center/edgecenteredgemon-go v0.1.0
 	github.com/Edge-Center/edgecenterprotection-go v0.1.7
 	github.com/connerdouglass/go-retry v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/Edge-Center/edgecentercdn-go v0.2.7 h1:CJs5wDFlN5PsvTOobUGndIsHBRKzzv
 github.com/Edge-Center/edgecentercdn-go v0.2.7/go.mod h1:aF3j7elRw9jmMc2BhdhKICj10En0pdO/JNWZ4BtICmQ=
 github.com/Edge-Center/edgecentercloud-go v0.1.11 h1:00h5o/71lEoSdU1B4AWmviuOfO28P6nsRP+afjIsW80=
 github.com/Edge-Center/edgecentercloud-go v0.1.11/go.mod h1:kmXGtx0lL1ib+SPfJe/uIAyDHamquAvqiftoLSyhxF8=
-github.com/Edge-Center/edgecentercloud-go/v2 v2.6.7 h1:UbjXx/4NrswqTho7tWBCeg0jAyedLKaFh4y/ztlczpE=
-github.com/Edge-Center/edgecentercloud-go/v2 v2.6.7/go.mod h1:aLN+G5rA8umwnIJ5U+f/cWNWdhhFRgWY0DZ6VyFXT6M=
+github.com/Edge-Center/edgecentercloud-go/v2 v2.7.0 h1:Qp2z5aFEKu0JEZnoCdDSX/vVdnG9AjnvHMckvbqCFKk=
+github.com/Edge-Center/edgecentercloud-go/v2 v2.7.0/go.mod h1:aLN+G5rA8umwnIJ5U+f/cWNWdhhFRgWY0DZ6VyFXT6M=
 github.com/Edge-Center/edgecenteredgemon-go v0.1.0 h1:+oyQK4o6tSpUC1R0QEp/U9/5YtImt+Klmf/ec2yngt4=
 github.com/Edge-Center/edgecenteredgemon-go v0.1.0/go.mod h1:+X+bLKzx+lr1C//4LvbKe9ZXMvoteWsHeAZ43fjJWcI=
 github.com/Edge-Center/edgecenterprotection-go v0.1.7 h1:f9AF/B8+5a9OqbF5lhegKSClGvPvRG18pqZRuDJPSFI=


### PR DESCRIPTION
Add DBaaS cluster access control support to the Terraform provider.

- add `access` block to resource and data source
- support access control update via API
- expose `private_host` and `public_host`
- update docs, example, and SDK version to `v2.6.10`